### PR TITLE
refactor: use pub exports

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -1,6 +1,6 @@
 use crate::commands::{self, Command};
 use crate::input::Input;
-use crate::output::Output;
+use crate::Output;
 
 pub fn new<TInput: Input, TOutput: Output>(
     options: Options<TInput, TOutput>,

--- a/src/commands/invalid.rs
+++ b/src/commands/invalid.rs
@@ -1,6 +1,6 @@
 use crate::commands::*;
 use crate::input::Input;
-use crate::output::Output;
+use crate::Output;
 
 pub fn new<TInput: Input, TOutput: Output>() -> Command<TInput, TOutput> {
     crate::commands::new::<TInput, TOutput>("invalid")

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,4 @@
-use crate::commands::*;
+use super::*;
 
 pub fn new<TInput: Input, TOutput: Output>() -> Command<TInput, TOutput> {
     crate::commands::new::<TInput, TOutput>("list")

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,5 @@
 use crate::input::Input;
-use crate::output::Output;
+use crate::Output;
 use clap::Arg;
 pub use colored::*;
 

--- a/src/input/argv.rs
+++ b/src/input/argv.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use clap::ArgMatches;
 
-use crate::input::Input;
+use crate::Input;
 
 pub fn new() -> Box<Argv> {
     let args = env::args();

--- a/src/input/inline.rs
+++ b/src/input/inline.rs
@@ -1,4 +1,4 @@
-use crate::input::Input;
+use crate::Input;
 use clap::ArgMatches;
 
 pub fn new(binary_name: String, arguments: Vec<String>) -> Box<Inline> {

--- a/src/input/null.rs
+++ b/src/input/null.rs
@@ -1,4 +1,4 @@
-use crate::input::Input;
+use crate::Input;
 use clap::ArgMatches;
 
 pub fn new() -> Box<Null> {

--- a/src/output/buffer.rs
+++ b/src/output/buffer.rs
@@ -1,4 +1,4 @@
-use crate::output::Output;
+use crate::Output;
 use regex::Regex;
 
 pub fn new() -> Box<Buffer> {

--- a/src/output/console.rs
+++ b/src/output/console.rs
@@ -1,4 +1,4 @@
-use crate::output::Output;
+use crate::Output;
 
 pub fn new() -> Box<Console> {
     Box::new(Console {})

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -2,7 +2,7 @@ pub mod alerts;
 pub mod buffer;
 pub mod console;
 
-use crate::output::alerts::Alert;
+use alerts::Alert;
 use colored::*;
 
 pub trait Output {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,6 +1,6 @@
 use crate::application::Application;
 use crate::input::Input;
-use crate::output::Output;
+use crate::Output;
 use clap::Command;
 
 pub fn run<TInput: Input, TOutput: Output>(


### PR DESCRIPTION
Lots of imports were using absolute names instead of the publically / library wide exports defined in `lib.rs`.